### PR TITLE
ci: use latest LTS release of node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 dist: trusty
 sudo: false
 language: node_js
-node_js:
-  - "8"
+node_js: lts/*
 
 install:
 - npm ci


### PR DESCRIPTION
fixes build error due to node.js v12 not being supported by node-sass yet